### PR TITLE
Fix Cucumber parallel run in ScenarioReporter mode

### DIFF
--- a/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
@@ -424,11 +424,13 @@ public abstract class AbstractReporter implements ConcurrentEventListener {
         RunningContext.FeatureContext currentFeatureContext;
         currentFeatureContext = new RunningContext.FeatureContext().processTestSourceReadEvent(testCase);
         currentFeatureContextMap.put(featureURI, currentFeatureContext);
+        String featureKeyword = currentFeatureContext.getFeature().getKeyword();
+        String featureName = currentFeatureContext.getFeature().getName();
 
         StartTestItemRQ rq = new StartTestItemRQ();
         Maybe<String> root = getRootItemId();
         rq.setDescription(currentFeatureContext.getUri());
-        rq.setName(featureURI.substring(featureURI.lastIndexOf('\\') + 1, featureURI.indexOf(".feature")));
+        rq.setName(Utils.buildNodeName(featureKeyword, AbstractReporter.COLON_INFIX, featureName, null));
         rq.setTags(currentFeatureContext.getTags());
         rq.setStartTime(Calendar.getInstance().getTime());
         rq.setType(getFeatureTestItemType());

--- a/src/main/java/com/epam/reportportal/cucumber/StepReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/StepReporter.java
@@ -110,6 +110,6 @@ public class StepReporter extends AbstractReporter {
 
     @Override
     protected String getScenarioTestItemType() {
-        return "SCENARIO";
+        return "TEST";
     }
 }


### PR DESCRIPTION
TODO: fix StepReporter mode (but do we really need it?)

fixes:
- parallel execution on cucumber_v4+ in ScenarioReporter mode
- [issue#8(parallel run of Scenario Outlines)](https://github.com/reportportal/agent-java-cucumber4/issues/8)

The only drawback is that it corrupts StepReporter mode in the same way as ScenarioReporter was failing - you can not run more then 1 thread. Didn't managed to figure out why yet...
But IMHO StepReporter mode in cucumber is useless anyway...  

@avarabyeu @DzmitryHumianiuk