### PR TITLE
[v5] Fix dependencies and compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,11 @@ repositories {
 
 dependencies {
     if (releaseMode) {
-        compile 'com.epam.reportportal:client-java:4.0.16'
-        compile 'com.epam.reportportal:commons-model:5.0.0-BETA-6'
+        compile 'com.epam.reportportal:client-java:5.0.0-BETA-1'
+        compile 'com.epam.reportportal:commons-model:5.0.0-BETA-7'
     } else {
-        compile 'com.github.reportportal:client-java:d27d103'
-        compile 'com.github.reportportal:commons-model:80bca7c'
+        compile 'com.github.reportportal:client-java:1173ab3'
+        compile 'com.github.reportportal:commons-model:c9e2d05'
     }
     compile 'io.cucumber:cucumber-java:4.5.4'
 }

--- a/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
@@ -25,7 +25,6 @@ import com.epam.ta.reportportal.ws.model.launch.StartLaunchRQ;
 import com.epam.ta.reportportal.ws.model.log.SaveLogRQ.File;
 import cucumber.api.*;
 import cucumber.api.event.*;
-import cucumber.api.formatter.Formatter;
 import io.reactivex.Maybe;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
@@ -46,7 +45,7 @@ import java.util.HashSet;
  * @author Serhii Zharskyi
  * @author Vitaliy Tsvihun
  */
-public abstract class AbstractReporter implements Formatter {
+public abstract class AbstractReporter implements ConcurrentEventListener {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractReporter.class);
 

--- a/src/main/java/com/epam/reportportal/cucumber/StepReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/StepReporter.java
@@ -17,12 +17,10 @@ package com.epam.reportportal.cucumber;
 
 import com.epam.reportportal.listeners.Statuses;
 import com.epam.ta.reportportal.ws.model.StartTestItemRQ;
-import cucumber.api.PickleStepTestStep;
 import cucumber.api.Result;
 import cucumber.api.TestStep;
 import gherkin.ast.Step;
 import io.reactivex.Maybe;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Calendar;
 


### PR DESCRIPTION
Fix dependencies + minor compile fix for AbstractReporter

- updated versions of client & model
- removed usage of gherkin.formatter.Formatter

Tested with:
- cucumber v4.2.6, v4.7.1
- client-java-5.0.0-BETA-1.jar
- commons-model-5.0.0-BETA-7.jar
@DzmitryHumianiuk @avarabyeu 